### PR TITLE
#48: Rename Std 'print(String,Object...)' to 'printf(String,Object...)'

### DIFF
--- a/src/main/java/io/github/dgroup/term4j/Std.java
+++ b/src/main/java/io/github/dgroup/term4j/Std.java
@@ -49,7 +49,7 @@ public interface Std {
      *  failure.
      * @see org.cactoos.text.FormattedText
      */
-    void print(String ptrn, Object... args);
+    void printf(String ptrn, Object... args);
 
     /**
      * Print each message to the separate line.

--- a/src/main/java/io/github/dgroup/term4j/std/StdEnvelope.java
+++ b/src/main/java/io/github/dgroup/term4j/std/StdEnvelope.java
@@ -56,7 +56,7 @@ public class StdEnvelope implements Std {
     }
 
     @Override
-    public final void print(final String ptrn, final Object... args) {
+    public final void printf(final String ptrn, final Object... args) {
         this.print(new FormattedText(ptrn, args));
     }
 

--- a/src/test/java/io/github/dgroup/term4j/std/StdOfTest.java
+++ b/src/test/java/io/github/dgroup/term4j/std/StdOfTest.java
@@ -53,7 +53,7 @@ public final class StdOfTest {
             final Std std = new StdOf(ps);
             std.print("line1", "line2");
             std.print("line3", "line4");
-            std.print("line%s", 5);
+            std.printf("line%s", 5);
         }
         new Assertion<>(
             "5 lines of text were printed to the output",


### PR DESCRIPTION
#48 
Methods
 - print(String... msgs)
 - void print(String ptrn, Object... args)
are confusing and can be invoked accidentally